### PR TITLE
RFXCOM binding: Add support of RFY and fix unitId conversion from UI

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
@@ -132,6 +132,7 @@ public class RFXComBindingConstants {
 	public final static ThingTypeUID THING_TYPE_RFX_SENSOR = new ThingTypeUID(BINDING_ID, "rfxsensor");
 	public final static ThingTypeUID THING_TYPE_RFX_METER = new ThingTypeUID(BINDING_ID, "rfxmeter");
 	public final static ThingTypeUID THING_TYPE_FS20 = new ThingTypeUID(BINDING_ID, "fs20");
+	public final static ThingTypeUID THING_TYPE_RFY = new ThingTypeUID(BINDING_ID, "rfy");
 
 	/**
 	 * Presents all supported Thing types by RFXCOM binding. 
@@ -155,7 +156,7 @@ public class RFXComBindingConstants {
 					THING_TYPE_POWER, THING_TYPE_WEIGHTING_SCALE,
 					THING_TYPE_GAS_USAGE, THING_TYPE_WATER_USAGE,
 					THING_TYPE_RFX_SENSOR, THING_TYPE_RFX_METER,
-					THING_TYPE_FS20);
+					THING_TYPE_FS20, THING_TYPE_RFY);
 
 	/**
 	 * Map RFXCOM packet types to RFXCOM Thing types and vice versa. 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComRfyMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComRfyMessage.java
@@ -219,7 +219,7 @@ public class RFXComRfyMessage extends RFXComBaseMessage {
 			throw new RFXComException("Invalid device id '" + deviceId + "'");
 		}
 
-		this.unitId = (byte) Short.parseShort(ids[0]);
+		this.unitId = Integer.parseInt(ids[0]);
 		this.unitCode = Byte.parseByte(ids[1]);
 	}
 


### PR DESCRIPTION
RFXCOM binding: Add support of RFY and fix Integer conversion of unitId coming from UI
